### PR TITLE
Docker support (#1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:latest
+
+ENV TZ=Europe/Kiev
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    g++ \
+    build-essential \
+    gperf \
+    openssl \
+    libssl-dev \
+    zlib1g-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN git clone --recursive https://github.com/tdlib/telegram-bot-api.git && \
+    cd telegram-bot-api/ && \
+    mkdir build && \
+    cd build
+
+WORKDIR telegram-bot-api/build
+
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build . --target install
+
+CMD ["telegram-bot-api","--api-id=$API_ID", "--api-hash=$API_HASH", "--local"]
+
+EXPOSE 8081


### PR DESCRIPTION
- added Docker support, users can build a small container for them selves without all the hesitations with one single command: `docker build --tag telegram-bot-api:latest .` and run with arguments (ENV Variables)
- api-id on Docker is `API_ID`
- api-hash on Docker is `API_HASH`