### PR TITLE
add instance_id params

### DIFF
--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -285,7 +285,7 @@ void ClientManager::start_up() {
     td::vector<td::uint64> failed_to_replay_log_event_ids;
     td::int64 loaded_event_count = 0;
     binlog
-        ->init(parameters_->working_directory_ + "tqueue.binlog",
+        ->init(parameters_->working_directory_ + parameters_->instance_id_ + "tqueue.binlog",
                [&](const td::BinlogEvent &event) {
                  if (tqueue_binlog->replay(event, *tqueue).is_error()) {
                    failed_to_replay_log_event_ids.push_back(event.id_);
@@ -316,7 +316,7 @@ void ClientManager::start_up() {
 
   // init webhook_db
   auto concurrent_webhook_db = td::make_unique<td::BinlogKeyValue<td::ConcurrentBinlog>>();
-  auto status = concurrent_webhook_db->init(parameters_->working_directory_ + "webhooks_db.binlog", td::DbKey::empty(),
+  auto status = concurrent_webhook_db->init(parameters_->working_directory_ + parameters_->instance_id_ + "webhooks_db.binlog", td::DbKey::empty(),
                                             scheduler_id);
   LOG_IF(FATAL, status.is_error()) << "Can't open webhooks_db.binlog " << status.error();
   parameters_->shared_data_->webhook_db_ = std::move(concurrent_webhook_db);

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -55,6 +55,7 @@ struct SharedData {
 };
 
 struct ClientParameters {
+  td::string instance_id_;
   td::string working_directory_;
   bool allow_colon_in_filenames_ = true;
 

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -211,6 +211,7 @@ int main(int argc, char *argv[]) {
   bool need_print_version = false;
   int http_port = 8081;
   int http_stat_port = 0;
+  td::string instance_id = "";
   td::string http_ip_address = "0.0.0.0";
   td::string http_stat_ip_address = "0.0.0.0";
   td::string log_file_path;
@@ -256,6 +257,7 @@ int main(int argc, char *argv[]) {
                              td::OptionParser::parse_integer(http_port));
   options.add_checked_option('s', "http-stat-port", "HTTP statistics port",
                              td::OptionParser::parse_integer(http_stat_port));
+  options.add_option('id', "instance-id", "The bot instance id, so that all bot data can be stored in the same folder", td::OptionParser::parse_string(instance_id));
   options.add_option('d', "dir", "server working directory", td::OptionParser::parse_string(working_directory));
   options.add_option('t', "temp-dir", "directory for storing HTTP server temporary files",
                      td::OptionParser::parse_string(temporary_directory));
@@ -442,6 +444,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
+  parameters->instance_id_ = std::move(instance_id);
   parameters->working_directory_ = std::move(working_directory);
 
   if (parameters->default_max_webhook_connections_ <= 0) {


### PR DESCRIPTION
The bot instance id, so that all bot data can be stored in the same folder.

Because the bot instance can only use 1 CPU, my 8 core CPU will have 8 processes open, but I want all the stored files to be in the same folder, this simplifies nginx when reading files from nginx configuration.