### PR TITLE
added alternative videos

### DIFF
--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -1764,38 +1764,67 @@ class Client::JsonChatPhoto final : public td::Jsonable {
   const Client *client_;
 };
 
-class Client::JsonVideo final : public td::Jsonable {
- public:
-  JsonVideo(const td_api::video *video, const td_api::photo *cover, int32 start_timestamp, const Client *client)
-      : video_(video), cover_(cover), start_timestamp_(start_timestamp), client_(client) {
-  }
-  void store(td::JsonValueScope *scope) const {
-    auto object = scope->enter_object();
-    object("duration", video_->duration_);
-    object("width", video_->width_);
-    object("height", video_->height_);
-    if (!video_->file_name_.empty()) {
-      object("file_name", video_->file_name_);
-    }
-    if (!video_->mime_type_.empty()) {
-      object("mime_type", video_->mime_type_);
-    }
-    if (cover_ != nullptr) {
-      object("cover", JsonPhoto(cover_, client_));
-    }
-    if (start_timestamp_ > 0) {
-      object("start_timestamp", start_timestamp_);
-    }
-    client_->json_store_thumbnail(object, video_->thumbnail_.get());
-    client_->json_store_file(object, video_->video_.get());
-  }
+class Client::JsonAlternativeVideo final : public td::Jsonable {
+  public:
+   JsonAlternativeVideo(const td_api::alternativeVideo *alternative_video, const Client *client)
+       : alternative_video_(alternative_video), client_(client) {
+   }
+   void store(td::JsonValueScope *scope) const {
+     auto object = scope->enter_object();
+     object("width", alternative_video_->width_);
+     object("height", alternative_video_->height_);
+     if (!alternative_video_->codec_.empty()) {
+       object("codec", alternative_video_->codec_);
+     }
+     client_->json_store_file(object, alternative_video_->video_.get());
+   }
+ 
+  private:
+   const td_api::alternativeVideo *alternative_video_;
+   const Client *client_;
+ };
 
- private:
-  const td_api::video *video_;
-  const td_api::photo *cover_;
-  int32 start_timestamp_;
-  const Client *client_;
-};
+ class Client::JsonVideo final : public td::Jsonable {
+  public:
+   JsonVideo(const td_api::video *video, const td_api::photo *cover, int32 start_timestamp, const Client *client)
+       : video_(video), cover_(cover), start_timestamp_(start_timestamp), alternative_videos_(), client_(client) {
+   }
+   JsonVideo(const td_api::video *video, const td_api::photo *cover, int32 start_timestamp, const td::vector<object_ptr<td_api::alternativeVideo>> &alternative_videos, const Client *client)
+       : video_(video), cover_(cover), start_timestamp_(start_timestamp), alternative_videos_(&alternative_videos), client_(client) {
+   }
+   void store(td::JsonValueScope *scope) const {
+     auto object = scope->enter_object();
+     object("duration", video_->duration_);
+     object("width", video_->width_);
+     object("height", video_->height_);
+     if (!video_->file_name_.empty()) {
+       object("file_name", video_->file_name_);
+     }
+     if (!video_->mime_type_.empty()) {
+       object("mime_type", video_->mime_type_);
+     }
+     if (cover_ != nullptr) {
+       object("cover", JsonPhoto(cover_, client_));
+     }
+     if (start_timestamp_ > 0) {
+       object("start_timestamp", start_timestamp_);
+     }
+     if (alternative_videos_ != nullptr && !alternative_videos_->empty()) {
+      object("alternative_videos", td::json_array(*alternative_videos_, [client = client_](const auto &alternative_video) {
+        return JsonAlternativeVideo(alternative_video.get(), client);
+      }));
+    }
+     client_->json_store_thumbnail(object, video_->thumbnail_.get());
+     client_->json_store_file(object, video_->video_.get());
+   }
+ 
+  private:
+   const td_api::video *video_;
+   const td_api::photo *cover_;
+   int32 start_timestamp_;
+   const td::vector<object_ptr<td_api::alternativeVideo>> *alternative_videos_;
+   const Client *client_;
+ };
 
 class Client::JsonVideoNote final : public td::Jsonable {
  public:
@@ -3447,7 +3476,8 @@ class Client::JsonExternalReplyInfo final : public td::Jsonable {
         }
         case td_api::messageVideo::ID: {
           auto content = static_cast<const td_api::messageVideo *>(reply_->content_.get());
-          object("video", JsonVideo(content->video_.get(), content->cover_.get(), content->start_timestamp_, client_));
+          object("video", JsonVideo(content->video_.get(), content->cover_.get(), content->start_timestamp_, 
+                                    content->alternative_videos_, client_));
           add_media_spoiler(object, content->has_spoiler_);
           break;
         }
@@ -3710,7 +3740,8 @@ void Client::JsonMessage::store(td::JsonValueScope *scope) const {
     }
     case td_api::messageVideo::ID: {
       auto content = static_cast<const td_api::messageVideo *>(message_->content.get());
-      object("video", JsonVideo(content->video_.get(), content->cover_.get(), content->start_timestamp_, client_));
+      object("video", JsonVideo(content->video_.get(), content->cover_.get(), content->start_timestamp_,
+                                content->alternative_videos_, client_));
       add_caption(object, content->caption_, content->show_caption_above_media_);
       add_media_spoiler(object, content->has_spoiler_);
       break;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -120,6 +120,7 @@ class Client final : public WebhookActor::Callback {
   class JsonSticker;
   class JsonStickers;
   class JsonVideo;
+  class JsonAlternativeVideo;
   class JsonVideoNote;
   class JsonVoiceNote;
   class JsonPaidMedia;


### PR DESCRIPTION
This change adds alternative videos to `message.video`. Currently bots are able to see the video but not its alternative versions. 