### PR TITLE
Return bots too in getChatAdministrators

### DIFF
--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -5126,12 +5126,6 @@ class Client::JsonChatMembers final : public td::Jsonable {
       if (member->member_id_->get_id() != td_api::messageSenderUser::ID) {
         continue;
       }
-      auto user_id = static_cast<const td_api::messageSenderUser *>(member->member_id_.get())->user_id_;
-      auto user_info = client_->get_user_info(user_id);
-      bool is_member_bot = user_info != nullptr && user_info->type == UserInfo::Type::Bot;
-      if (is_member_bot && user_id != client_->my_id_) {
-        continue;
-      }
       if (administrators_only_) {
         auto status = Client::get_chat_member_status(member->status_);
         if (status != "creator" && status != "administrator") {


### PR DESCRIPTION
This pull requests removes the "is_member_bot" condition in JsonChatMembers, which is only used by "TdOnGetGroupMembersCallback" and "TdOnGetSupergroupMembersCallback", which are only used by the getChatAdministrators method (process_get_chat_administrators_query).
Therefore, getChatAdministrators will return bots too, if they are admins of the chat.
This is especially useful after the introduction of the Bot-to-Bot communication mode.