### PR TITLE
Add --allowed-bot-ids option to whitelist bots

### DIFF
--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -83,6 +83,11 @@ void ClientManager::send(PromisedQueryPtr query) {
   if (user_id <= 0 || user_id >= (static_cast<td::int64>(1) << 54)) {
     return fail_query(401, "Unauthorized: invalid token specified", std::move(query));
   }
+  const auto &allowed_bot_user_ids = parameters_->allowed_bot_user_ids_;
+  if (!allowed_bot_user_ids.empty() &&
+      std::find(allowed_bot_user_ids.begin(), allowed_bot_user_ids.end(), user_id) == allowed_bot_user_ids.end()) {
+    return fail_query(401, "Unauthorized: bot is not allowed to use the server", std::move(query));
+  }
 
   if (query->is_test_dc()) {
     token += "/test";

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -115,6 +115,8 @@ struct ClientParameters {
 
   td::string version_;
 
+  td::vector<td::int64> allowed_bot_user_ids_;  // empty means that all bots are allowed
+
   td::int32 default_max_webhook_connections_ = 0;
   td::IPAddress webhook_proxy_ip_address_;
 

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -243,6 +243,19 @@ int main(int argc, char *argv[]) {
                                token_range = {rem_i, mod_i};
                                return td::Status::OK();
                              });
+  options.add_checked_option('\0', "allowed-bot-ids",
+                             "comma-separated list of bot user identifiers that are allowed to use the server. By "
+                             "default, all bots are allowed",
+                             [&](td::Slice ids) -> td::Status {
+                               for (auto id_str : td::full_split(ids, ',')) {
+                                 TRY_RESULT(user_id, td::to_integer_safe<td::int64>(id_str));
+                                 if (user_id <= 0) {
+                                   return td::Status::Error("Invalid bot user identifier specified");
+                                 }
+                                 parameters->allowed_bot_user_ids_.push_back(user_id);
+                               }
+                               return td::Status::OK();
+                             });
   options.add_checked_option('\0', "max-webhook-connections",
                              "default value of the maximum webhook connections per bot",
                              td::OptionParser::parse_integer(parameters->default_max_webhook_connections_));


### PR DESCRIPTION
Adds an optional `--allowed-bot-ids` command-line option that takes a comma-separated list of bot user identifiers permitted to use the server.

When the option is set, a request whose bot user id is not in the list is rejected with `401 Unauthorized: bot is not allowed to use the server` in `ClientManager::send`, before any `Client` is created — so unknown bots can't consume server resources (memory, TDLib instances, database entries). When the option is omitted the behavior is unchanged: all bots are allowed.

This complements the existing `--filter` option: `--filter` partitions bots across server instances by `bot_user_id % modulo`, whereas `--allowed-bot-ids` restricts the server to an explicit allowlist, which is useful for single-tenant or private deployments.

### Changes
- `ClientParameters`: add `allowed_bot_user_ids_` (empty means all bots allowed).
- `telegram-bot-api.cpp`: parse and validate the `--allowed-bot-ids` option.
- `ClientManager::send`: reject bot ids outside the allowlist with 401.