### PR TITLE
Add Docker image and multi-arch CI build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+build
+Dockerfile
+.dockerignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,131 @@
+name: Docker
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v5
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge and push manifest
+    runs-on: ubuntu-24.04
+    needs: build
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v5
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:13-slim AS build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        g++ make cmake git gperf libssl-dev zlib1g-dev ccache ninja-build \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+ENV CCACHE_DIR=/ccache
+RUN --mount=type=cache,target=/ccache \
+    cmake -S . -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build build --target install \
+    && ccache -s
+
+FROM debian:13-slim
+
+# openssl provides libssl/libcrypto whatever the versioned library package is
+# named; zlib1g is already in the base image but is listed explicitly since the
+# server links against it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates openssl zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/local/bin/telegram-bot-api /usr/local/bin/telegram-bot-api
+
+WORKDIR /var/lib/telegram-bot-api
+EXPOSE 8081
+ENTRYPOINT ["/usr/local/bin/telegram-bot-api"]
+CMD ["--verbosity=2", "--temp-dir=/tmp/telegram-bot-api"]


### PR DESCRIPTION
Adds an official `Dockerfile` and a GitHub Actions workflow that builds and publishes a multi-arch container image.

### Dockerfile
- Multi-stage build on `debian:13-slim`.
  - Build stage installs the toolchain (`g++`, `cmake`, `ninja-build`, `gperf`, `libssl-dev`, `zlib1g-dev`, `ccache`) and builds with `-DCMAKE_BUILD_TYPE=Release`. A BuildKit cache mount keeps the `ccache` directory warm between builds.
  - Runtime stage carries only the server binary plus the shared libraries it links against (`ca-certificates`, `openssl`, `zlib1g`), keeping the final image small.
- The server binary is the image `ENTRYPOINT`; the default `CMD` runs with `--verbosity=2 --temp-dir=/tmp/telegram-bot-api`. The API id/hash are supplied at runtime via `TELEGRAM_API_ID` / `TELEGRAM_API_HASH` or flags.

### CI workflow (`.github/workflows/docker.yml`)
- Builds `linux/amd64` and `linux/arm64` **natively** on their respective GitHub-hosted runners (`ubuntu-24.04` and `ubuntu-24.04-arm`) rather than under QEMU emulation, which matters a lot for a from-source C++ build.
- Each platform is pushed to GHCR by digest; a final `merge` job assembles the per-arch digests into a single multi-arch manifest and tags it (branch, tag, and `sha`).
- Uses GitHub Actions layer cache (`type=gha`, scoped per platform). On `pull_request` the image is built but not pushed.

The image is published to `ghcr.io/${{ github.repository }}`.